### PR TITLE
workaround for intermittent 'text file busy' bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY run-services.sh /run-services.sh
 COPY dist/buildagent /opt/buildagent
 
 RUN useradd -m buildagent && \
-    chmod +x /run-agent.sh /run-services.sh
+    chmod +x /run-agent.sh /run-services.sh && sync
 
 CMD ["/run-services.sh"]
 

--- a/run-services.sh
+++ b/run-services.sh
@@ -6,7 +6,7 @@ for entry in /services/*.sh
 do
   echo $entry
   if [ -f $entry ]; then
-      chmod +x $entry && sync
+      chmod +x $entry; sync;
       $entry
   fi
 done

--- a/run-services.sh
+++ b/run-services.sh
@@ -6,7 +6,7 @@ for entry in /services/*.sh
 do
   echo $entry
   if [ -f $entry ]; then
-      chmod +x $entry
+      chmod +x $entry && sync
       $entry
   fi
 done


### PR DESCRIPTION
Running files just after chmod +x'ing them sometimes causes a 'text file busy' error which prevents proper container operation. A call to sync alleviates these issues by flushing the chmod's changes before running the script that has been chmod'ed.

my earlier pull request messed up non-minimal agents but this one seems ok.