### PR TITLE
replace current process when starting run-agent.sh

### DIFF
--- a/run-services.sh
+++ b/run-services.sh
@@ -12,4 +12,4 @@ do
 done
 
 echo '/run-agent.sh'
-/run-agent.sh
+exec /run-agent.sh


### PR DESCRIPTION
replace current process when starting run-agent.sh to allow signals to be handled when container is stopped. As discussed is issue #6 to allow clean shutdown of agent.