### PR TITLE
set exit status on clean shutdown. Follow logs even after roll

### DIFF
--- a/run-agent.sh
+++ b/run-agent.sh
@@ -56,9 +56,9 @@ do
    sleep 1
 done
 
-trap "${AGENT_DIST}/bin/agent.sh stop" SIGINT SIGTERM SIGHUP
+trap "${AGENT_DIST}/bin/agent.sh stop;exit 0;" SIGINT SIGTERM SIGHUP
 
 touch /root/anchor
 
-tail -qf ${LOG_DIR}/teamcity-agent.log /root/anchor &
+tail -qF ${LOG_DIR}/teamcity-agent.log /root/anchor &
 wait


### PR DESCRIPTION
After previous commit to handle signals correctly, the trap should set a exit code if successfully called so the correct exit code is returned to docker.

Also set tail command to follow log after logs are rotated.