### PR TITLE
Properly shutdown agent and script gracefully

### DIFF
--- a/run-agent.sh
+++ b/run-agent.sh
@@ -74,9 +74,7 @@ do
    sleep 1
 done
 
-trap "${AGENT_DIST}/bin/agent.sh stop; exit 0;" SIGINT SIGTERM SIGHUP
+trap '${AGENT_DIST}/bin/agent.sh stop; while ps -p $(cat $(ls -1 ${LOG_DIR}/*.pid)) &>/dev/null; do sleep 1; done; kill %%' SIGINT SIGTERM SIGHUP
 
-touch /root/anchor
-
-tail -qF ${LOG_DIR}/teamcity-agent.log /root/anchor &
+tail -qF ${LOG_DIR}/teamcity-agent.log &
 wait


### PR DESCRIPTION
- remove anchor usage as it is obsolete

  Please correct me if I'm wrong as I find no
  documentation about it. I guess it is a leftover
  from when it was necessary. I have seen you had
  formerly `tail -qf` instead of `tail -qF`. The
  former fails if none of the specified files can
  be found as the files are shown by inode, so there
  is nothing senseful to do. As the latter is showing 
  the files by name, the files can appear after starting,
  so the `tail` will not exit in error but continue running.
  But even with the `-f` the `tail` would have always
  worked as before the tail there is a loop that waits
  for the log file to appear. So I guess the anchor file
  was just as safety precaution in case the log file
  disappears between waiting for it and starting the `tail`
  or from a time where the script didn't wait for the log
  file to appear. As far as I can tell with the `-F` the
  anchor file is totally obsolete and even the waiting for
  the log file could be removed. But as it shows a progress
  meter (the dots), I kept it there.

- use single quotes for the trap command
  to have late evaluation of placeholders

  This is necessary so that the pid files are not read too early,
  but then when we want to wait for the processes.

- do not force exit of the script with `exit 0`
  but instead kill the `tail` background job,
  the `wait` is waiting for with `kill %%`

  This will kill the last started background job,
  which is the only one we have, the `tail` command.
  Using `exit` the `tail` command still lurks around
  as orphan process, so it is better to properly kill it
  instead of just exiting the parent script forcefully.

- do not immediately exit after `agent.sh stop`
  was called which is just the launcher being
  finished instructing the agent to shutdown;
  when exiting immediately most often the agent
  has no chance to cleanly unregister from the
  server and TeamCity will show a warning when
  used in the Docker Cloud plugin; instead wait
  for the agent process to die before continuing
  by killing the `tail` and exiting the script