### PR TITLE
Add LANG env

### DIFF
--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -3,6 +3,7 @@ FROM adoptopenjdk/openjdk8:x86_64-ubuntu-jdk8u192-b12
 MAINTAINER Kateryna Shlyakhovetska <shkate@jetbrains.com>
 
 VOLUME /data/teamcity_agent/conf
+ENV LANG C.UTF-8
 ENV CONFIG_FILE /data/teamcity_agent/conf/buildAgent.properties
 LABEL dockerImage.teamcity.version="latest" \
       dockerImage.teamcity.buildNumber="latest"


### PR DESCRIPTION
After this commit: https://github.com/JetBrains/teamcity-docker-minimal-agent/commit/73f8daaab568af86381d9acf4282400b8a2e19ab#diff-36587a08e076cdecce7ecf9ad77f533eR1

No LANG ENV config in the base image.

We can add it back.