### PR TITLE
moved chown to build step to prevent permission denied in OpenShift

### DIFF
--- a/run-agent.sh
+++ b/run-agent.sh
@@ -48,7 +48,7 @@ CONFIG_DIR=/data/teamcity_agent/conf
 
 LOG_DIR=/opt/buildagent/logs
 
-chmod +x ${AGENT_DIST}/bin/*.sh; check; sync
+check; sync
 
 rm -f ${LOG_DIR}/*.pid
 

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -13,6 +13,7 @@ COPY run-services.sh /run-services.sh
 COPY dist/buildagent /opt/buildagent
 
 RUN useradd -m buildagent && \
+    chmod +x /opt/buildagent/bin/*.sh && \
     chmod +x /run-agent.sh /run-services.sh && sync
 
 CMD ["/run-services.sh"]


### PR DESCRIPTION
Moved chown of buildagent scripts from the container instantiation to the docker build process. Without this step, the image either needs "runasany" security context constraint on OpenShift, or it will fail to start. 