### PR TITLE
cleanup after apt update

### DIFF
--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -14,6 +14,7 @@ COPY dist/buildagent /opt/buildagent
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends sudo && \
+    rm -rf /var/lib/apt/lists/* && \
     useradd -m buildagent && \
     chmod +x /opt/buildagent/bin/*.sh && \
     chmod +x /run-agent.sh /run-services.sh && sync


### PR DESCRIPTION
this avoids wasting 25MB space of the entire image.