### PR TITLE
Add an alpine 3.9 minimal agent image

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,0 +1,24 @@
+FROM openjdk:8u212-alpine3.9
+
+VOLUME /data/teamcity_agent/conf
+
+ENV CONFIG_FILE=/data/teamcity_agent/conf/buildAgent.properties \
+    LANG=C.UTF-8
+
+LABEL dockerImage.teamcity.version="latest" \
+      dockerImage.teamcity.buildNumber="latest"
+
+COPY run-agent.sh /run-agent.sh
+COPY run-services.sh /run-services.sh
+COPY dist/buildagent /opt/buildagent
+
+RUN apk update && \
+    apk add sudo bash && \
+    addgroup -g 1001 buildagent && \
+    adduser -u 1001 --disabled-password -S buildagent -G buildagent && \
+    chmod +x /opt/buildagent/bin/*.sh && \
+    chmod +x /run-agent.sh /run-services.sh && sync
+
+CMD ["/run-services.sh"]
+
+EXPOSE 9090


### PR DESCRIPTION
Adds a minimal agent image based on the `openjdk` alpine image.

The agent should be equivalent to the `ubuntu` minimal agent image.

Currently it:
- Creates a new user/goup called `buildagent`
- Installs sudo and bash
- Copies the agent distribution