### PR TITLE
In order to write to C:\ we need Admin access

### DIFF
--- a/nanoserver/1809/Dockerfile
+++ b/nanoserver/1809/Dockerfile
@@ -2,6 +2,9 @@ FROM mcr.microsoft.com/powershell:nanoserver-1809 AS base
 
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
+# In order to write to C:\, ContainerAdministrator must be used
+USER ContainerAdministrator
+
 # Install JRE
 RUN [Net.ServicePointManager]::SecurityProtocol = 'tls12, tls11, tls' ; \
     Invoke-WebRequest https://corretto.aws/downloads/resources/8.252.09.2/amazon-corretto-8.252.09.2-windows-x64-jre.zip -OutFile jre.zip; \


### PR DESCRIPTION
On 1809 using Windows Server 2019 we need ContainerAdministrator to write to C:\ inside the container.
See also here: https://github.com/PowerShell/PowerShell-Docker/issues/423